### PR TITLE
Bugfix/packet decimal place adjustment

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -612,7 +612,7 @@ void configurePressureSensor() {
 void sendDataToDashboard() {
     
     String delimiter = ";";
-    String dataString = String(currentPressure.value, 3) + delimiter; // 3 decimal places of precision for pressure
+    String dataString = String(currentPressure.value, 7) + delimiter; // 7 decimal places of precision for pressure
     dataString += currentPressure.rawStr + delimiter;
 
     // Get current system switch states

--- a/main/main.ino
+++ b/main/main.ino
@@ -20,7 +20,7 @@ const int rs = 12, en = 10, d4 = 5, d5 = 4, d6 = 3, d7 = 2; // 20x4 LCD pin conn
 **/
 #define DEBUG_MODE                      true        // Set this false to disable debug logging
 #define ERROR_CHECKING_ENABLED          1           // Set this 0 to disable error checking
-#define FIRMWARE_VERSION                "v.1.5"
+#define FIRMWARE_VERSION                "v.1.6"
 #define EXPECTED_AMBIENT_PRESSURE       1010.0      // Nominal ambient pressure [millibar]
 #define AMBIENT_PRESSURE_THRESHOLD      200.0       // 20% tolerance level for ambient [millibar]
 #define HIGH_VACUUM_THRESHOLD           1.00E-4


### PR DESCRIPTION
Numeric pressure values below 10E-3 are interpreted as `0.0` by the EBEAM_dashboard.

We believe this was due to the `decimalPlaces=3` parameter in the `String()` cast prior to sending the data packet.

This PR increases the decimal places to 7 to carry through greater precision numbers. 