### PR TITLE
Correct VTRX input signal labeling

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -8,7 +8,7 @@
 #define PUMPS_POWER_ON_PIN              41
 #define TURBO_ROTOR_ON_PIN              40
 #define TURBO_VENT_OPEN_PIN             39
-#define PRESSURE_GAUGE_POWER_ON_PIN     38
+#define PRESSURE_GAUGE_RELAY1_PIN       38
 #define TURBO_GATE_VALVE_OPEN_PIN       34
 #define TURBO_GATE_VALVE_CLOSED_PIN     33
 #define ARGON_GATE_VALVE_CLOSED_PIN     32
@@ -53,7 +53,7 @@ struct SwitchStates {
   int pumpsPowerOn;
   int turboRotorOn;
   int turboVentOpen;
-  int pressureGaugePowerOn;
+  int pressureGaugeRelay1Energized;
   int turboGateValveOpen;
   int turboGateValveClosed;
   int argonGateValveClosed;
@@ -129,7 +129,7 @@ void setup() {
     pinMode(PUMPS_POWER_ON_PIN, INPUT);
     pinMode(TURBO_ROTOR_ON_PIN, INPUT);
     pinMode(TURBO_VENT_OPEN_PIN, INPUT);
-    pinMode(PRESSURE_GAUGE_POWER_ON_PIN, INPUT);
+    pinMode(PRESSURE_GAUGE_RELAY1_PIN, INPUT);
     pinMode(TURBO_GATE_VALVE_OPEN_PIN, INPUT);
     pinMode(TURBO_GATE_VALVE_CLOSED_PIN, INPUT);
     pinMode(ARGON_GATE_VALVE_CLOSED_PIN, INPUT);
@@ -275,7 +275,7 @@ SwitchStates readSystemSwitchStates() {
     states.pumpsPowerOn = digitalRead(PUMPS_POWER_ON_PIN);
     states.turboRotorOn = digitalRead(TURBO_ROTOR_ON_PIN);
     states.turboVentOpen = digitalRead(TURBO_VENT_OPEN_PIN);
-    states.pressureGaugePowerOn = digitalRead(PRESSURE_GAUGE_POWER_ON_PIN);
+    states.pressureGaugeRelay1Energized = digitalRead(PRESSURE_GAUGE_RELAY1_PIN);
     states.turboGateValveOpen = digitalRead(TURBO_GATE_VALVE_OPEN_PIN);
     states.turboGateValveClosed = digitalRead(TURBO_GATE_VALVE_CLOSED_PIN);
     states.argonGateValveClosed = digitalRead(ARGON_GATE_VALVE_CLOSED_PIN);
@@ -622,7 +622,7 @@ void sendDataToDashboard() {
     int compactedSwitchStates = (state.pumpsPowerOn << 7) |
                                 (state.turboRotorOn << 6) |
                                 (state.turboVentOpen << 5) |
-                                (state.pressureGaugePowerOn << 4) |
+                                (state.pressureGaugeRelay1Energized << 4) |
                                 (state.turboGateValveOpen << 3) |
                                 (state.turboGateValveClosed << 2) |
                                 (state.argonGateValveClosed << 1) |

--- a/main/main.ino
+++ b/main/main.ino
@@ -9,10 +9,10 @@
 #define TURBO_ROTOR_ON_PIN              40
 #define TURBO_VENT_OPEN_PIN             39
 #define PRESSURE_GAUGE_RELAY1_PIN       38
-#define TURBO_GATE_VALVE_OPEN_PIN       34
-#define TURBO_GATE_VALVE_CLOSED_PIN     33
-#define ARGON_GATE_VALVE_CLOSED_PIN     32
-#define ARGON_GATE_VALVE_OPEN_PIN       31
+#define TURBO_GATE_VALVE_CLOSED_PIN     34
+#define TURBO_GATE_VALVE_OPEN_PIN       33
+#define ARGON_GATE_VALVE_OPEN_PIN       32
+#define ARGON_GATE_VALVE_CLOSED_PIN     31
 const int rs = 12, en = 10, d4 = 5, d5 = 4, d6 = 3, d7 = 2; // 20x4 LCD pin connections
 //const int rs = 22, en = 23, d4 = 24, d5 = 25, d6 = 26, d7 = 27; // 20x4 LCD pin connections
 /**
@@ -54,10 +54,10 @@ struct SwitchStates {
   int turboRotorOn;
   int turboVentOpen;
   int pressureGaugeRelay1Energized;
-  int turboGateValveOpen;
   int turboGateValveClosed;
-  int argonGateValveClosed;
+  int turboGateValveOpen;
   int argonGateValveOpen;
+  int argonGateValveClosed;
 };
 
 enum ErrorCode {
@@ -130,10 +130,10 @@ void setup() {
     pinMode(TURBO_ROTOR_ON_PIN, INPUT);
     pinMode(TURBO_VENT_OPEN_PIN, INPUT);
     pinMode(PRESSURE_GAUGE_RELAY1_PIN, INPUT);
-    pinMode(TURBO_GATE_VALVE_OPEN_PIN, INPUT);
     pinMode(TURBO_GATE_VALVE_CLOSED_PIN, INPUT);
-    pinMode(ARGON_GATE_VALVE_CLOSED_PIN, INPUT);
+    pinMode(TURBO_GATE_VALVE_OPEN_PIN, INPUT);
     pinMode(ARGON_GATE_VALVE_OPEN_PIN, INPUT); 
+    pinMode(ARGON_GATE_VALVE_CLOSED_PIN, INPUT);
     
     if (DEBUG_MODE) {
         //errorQueue.setPrinter(Serial); // TODO: implement
@@ -276,10 +276,10 @@ SwitchStates readSystemSwitchStates() {
     states.turboRotorOn = digitalRead(TURBO_ROTOR_ON_PIN);
     states.turboVentOpen = digitalRead(TURBO_VENT_OPEN_PIN);
     states.pressureGaugeRelay1Energized = digitalRead(PRESSURE_GAUGE_RELAY1_PIN);
-    states.turboGateValveOpen = digitalRead(TURBO_GATE_VALVE_OPEN_PIN);
     states.turboGateValveClosed = digitalRead(TURBO_GATE_VALVE_CLOSED_PIN);
-    states.argonGateValveClosed = digitalRead(ARGON_GATE_VALVE_CLOSED_PIN);
+    states.turboGateValveOpen = digitalRead(TURBO_GATE_VALVE_OPEN_PIN);
     states.argonGateValveOpen = digitalRead(ARGON_GATE_VALVE_OPEN_PIN);
+    states.argonGateValveClosed = digitalRead(ARGON_GATE_VALVE_CLOSED_PIN);
 
     return states;
 }
@@ -618,15 +618,18 @@ void sendDataToDashboard() {
     // Get current system switch states
     SwitchStates state = readSystemSwitchStates();
 
-    // Compact switch state data into a single integer (bitwise representation)
+    // Dashboard switch-state bit contract (MSB to LSB):
+    // 7: Pumps Power ON, 6: Turbo Rotor ON, 5: Turbo Vent OPEN,
+    // 4: 972B Relay 1 ON, 3: Turbo Gate CLOSED, 2: Turbo Gate OPEN,
+    // 1: Argon Gate OPEN, 0: Argon Gate CLOSED.
     int compactedSwitchStates = (state.pumpsPowerOn << 7) |
                                 (state.turboRotorOn << 6) |
                                 (state.turboVentOpen << 5) |
                                 (state.pressureGaugeRelay1Energized << 4) |
-                                (state.turboGateValveOpen << 3) |
-                                (state.turboGateValveClosed << 2) |
-                                (state.argonGateValveClosed << 1) |
-                                (state.argonGateValveOpen);
+                                (state.turboGateValveClosed << 3) |
+                                (state.turboGateValveOpen << 2) |
+                                (state.argonGateValveOpen << 1) |
+                                (state.argonGateValveClosed);
     
     dataString += String(compactedSwitchStates, BIN); // Send switch states as a binary string
 


### PR DESCRIPTION
## Summary

This PR merges the current `develop` changes into `main` and corrects misleading firmware names for the VTRX discrete inputs:

- Renames Arduino D38 from a 972B power indication to the 972B Relay 1 energized state.
- Corrects the Turbo and Argon gate-valve OPEN/CLOSED pin names.
- Documents the complete dashboard switch-state bit contract beside the packing logic.
- Preserves the existing dashboard packet and physical bit positions.

## Confirmed signal mapping

| Bit | Arduino | VTRX-240 channel | Physical state |
| ---: | ---: | ---: | --- |
| 7 | D41 | 1 | Pumps Power ON |
| 6 | D40 | 2 | Turbo Rotor ON |
| 5 | D39 | 3 | Turbo Vent OPEN |
| 4 | D38 | 4 | 972B Relay 1 ON |
| 3 | D34 | 5 | Turbo Gate CLOSED |
| 2 | D33 | 6 | Turbo Gate OPEN |
| 1 | D32 | 7 | Argon Gate OPEN |
| 0 | D31 | 8 | Argon Gate CLOSED |

## Why

The VTRX System Schematic and Peripherals Hook-up Diagram, revision `2024-11-12A-CO`, show that:

- D38 is isolated through VTRX-240 channel 4 and originates from the 972B Relay 1 normally-open contact, not a gauge-power output.
- D34/channel 5 traces to the Turbo Gate CLOSED indication.
- D33/channel 6 traces to the Turbo Gate OPEN indication.
- D32/channel 7 traces to the Argon Gate OPEN indication.
- D31/channel 8 traces to the Argon Gate CLOSED indication.

The previous identifiers described the opposite valve state even though the raw input bits already occupied the correct physical positions.

## Impact

This is a semantic correction with no protocol or control behavior change:

- No Arduino pin numbers change.
- No physical dashboard bit positions change.
- No 972B relay configuration changes.
- Valve-contention checks continue to test both OPEN and CLOSED inputs.
- Existing consumers receive the same raw switch-state values.

Dashboard UI text outside this repository should use the confirmed mapping above.

## Validation

- Verified the low nibble remains physically equivalent to `D34<<3 | D33<<2 | D32<<1 | D31`.
- Verified one-hot values: D34=`0x08`, D33=`0x04`, D32=`0x02`, D31=`0x01`.
- Confirmed both Turbo and Argon contention checks still reference their corrected OPEN and CLOSED states.
- `git diff --check` passes.
- Confirmed the four incorrect pin/name associations are gone.
- A firmware compile was not run because `arduino-cli` is not installed in the current environment.

This PR remains a draft and has not been merged.